### PR TITLE
feat: extend notifications and simplify tabs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,19 @@
 # neverpaste
+
+## Notifications
+
+Example usage:
+
+```lua
+addNotification(
+    "Update complete",
+    "All files downloaded",
+    faicons("check"),
+    {
+        duration = 5,
+        iconColor = imgui.ImVec4(0,1,0,1),
+        barColor = imgui.ImVec4(1,0,0,1),
+        onClick = function() print("clicked") end
+    }
+)
+```


### PR DESCRIPTION
## Summary
- simplify TabButton to avoid animation conflicts
- allow notifications to accept configurable options and click callbacks
- document notification usage and examples

## Testing
- `luac -p 'Neverlose 1.1.9.lua'`


------
https://chatgpt.com/codex/tasks/task_e_68a4ff9c7818832da5e6ec0c89a3e7fc